### PR TITLE
fix: fix a typo causes useless calculation

### DIFF
--- a/lib/resty/timerng/job.lua
+++ b/lib/resty/timerng/job.lua
@@ -251,7 +251,7 @@ function _M.new(wheels, name, callback, delay, once, debug, argc, argv)
         NAME_COUNTER = NAME_COUNTER + 1
     end
 
-    if not self.immediate then
+    if not self._immediate then
         job_re_cal_next_pointer(self, wheels)
     end
 


### PR DESCRIPTION
Fix typo in job.lua :)
See https://github.com/Kong/lua-resty-timer-ng/issues/16