### PR TITLE
fix: the timer should not be running early.

### DIFF
--- a/lib/resty/timerng/job.lua
+++ b/lib/resty/timerng/job.lua
@@ -245,9 +245,12 @@ function _M.new(wheels, name, callback, delay, once, debug, argc, argv)
         job_create_meta(self)
     end
 
+    local create_time = ngx_now()
+    self.create_time = create_time
+
     if self.name == nil then
         self.name = string_format("unix_timestamp=%f;counter=%d:meta=%s",
-                                  math_floor(ngx_now() * 1000),
+                                  math_floor(create_time * 1000),
                                   NAME_COUNTER,
                                   self.meta.name)
 

--- a/lib/resty/timerng/wheel/group.lua
+++ b/lib/resty/timerng/wheel/group.lua
@@ -1,3 +1,5 @@
+local math_floor = math.floor
+
 local utils = require("resty.timerng.utils")
 local wheel = require("resty.timerng.wheel")
 local array = require("resty.timerng.array")
@@ -103,6 +105,7 @@ function _M:sync_time()
         return
     end
 
+    self.real_time = math_floor(self.real_time / resolution) * resolution
     local delta = self.real_time - self.expected_time
     local steps = utils_convert_second_to_step(delta, resolution)
 

--- a/spec/09-jump_the_gun_spec.lua
+++ b/spec/09-jump_the_gun_spec.lua
@@ -1,0 +1,98 @@
+
+local timer_module = require("resty.timerng")
+local helper = require("helper")
+
+local sleep = ngx.sleep
+local update_time = ngx.update_time
+local now = ngx.now
+local timer_running_count = ngx.timer.running_count
+local string_format = string.format
+
+
+local function callback_func(premature, create_time, delay)
+    if premature then
+        return
+    end
+
+    update_time()
+    local now = now()
+    local dict = ngx.shared["timer_jump_the_gun"]
+    if not dict then
+        error("not found shared dict: timer_jump_the_gun")
+        return
+    end
+
+    dict:set("not_jump_the_gun", now - delay > create_time)
+end
+
+
+local function every_func()
+    update_time()
+end
+
+insulate("timer jump the gun", function ()
+    local timer = { }
+
+    randomize()
+
+    lazy_setup(function ()
+        timer = timer_module.new({
+            min_threads = 16,
+            max_threads = 32,
+        })
+
+        assert(timer:start())
+
+    end)
+
+    lazy_teardown(function ()
+        timer:freeze()
+        timer:destroy()
+
+        helper.wait_until(function ()
+            assert.same(1, timer_running_count())
+            return true
+        end)
+
+    end)
+
+    after_each(function ()
+        assert.has_no.errors(function ()
+            timer:cancel(helper.TIMER_NAME_ONCE)
+        end)
+    end)
+
+    it("test", function ()
+        local delay = 50 * helper.RESOLUTION
+        local interval = 10 * helper.RESOLUTION
+        update_time()
+
+        assert.has_no.errors(function ()
+            assert(
+                timer:every(interval, every_func)
+            )
+        end)
+
+        ngx.sleep(0.999)
+
+        update_time()
+        assert.has_no.errors(function ()
+            local create_time = now()
+            assert(
+                timer:named_at("foo", delay, callback_func, create_time, delay)
+            )
+        end)
+
+        sleep(6)
+
+        local dict = ngx.shared["timer_jump_the_gun"]
+        if not dict then
+            error("not found shared dict: timer_jump_the_gun")
+            return
+        end
+
+        local jump_the_gun = dict:get("not_jump_the_gun")
+        assert.is_not_nil(jump_the_gun)
+        assert.is_true(jump_the_gun)
+    end)
+end)


### PR DESCRIPTION
This PR fixes the error of timer running early.
When calculating steps, discard the part of `self.real_time` that exceeds the resolution, so that the calculation of steps will not count extra points that have not yet expired.