### PR TITLE
Allow zero `interval` on `named_every`

### DIFF
--- a/lib/resty/timerng/init.lua
+++ b/lib/resty/timerng/init.lua
@@ -403,7 +403,7 @@ function _M:named_every(name, interval, callback, ...)
     assert(type(callback) == "function", "expected `callback` to be a function")
 
     assert(type(interval) == "number", "expected `interval to be a number")
-    assert(interval > 0, "expected `interval` to be greater than or equal to 0")
+    assert(interval >= 0, "expected `interval` to be greater than or equal to 0")
 
     if interval >= self.max_expire or
        interval < self.opt.resolution

--- a/spec/03-every_spec.lua
+++ b/spec/03-every_spec.lua
@@ -70,11 +70,7 @@ insulate("create a every timer with invalid arguments | ", function ()
     end)
 
 
-    it("interval <= 0", function ()
-        assert.has.errors(function ()
-            timer:named_every(helper.TIMER_NAME_EVERT, 0, empty_callback)
-        end)
-
+    it("interval < 0", function ()
         assert.has.errors(function ()
             timer:named_every(helper.TIMER_NAME_EVERT, -1, empty_callback)
         end)


### PR DESCRIPTION
* the assert says "expected `interval` to be greater than or equal to 0"
* the timer allows zero value - ref https://github.com/Kong/lua-resty-timer/blob/master/lib/resty/timer.lua#L147